### PR TITLE
removed port

### DIFF
--- a/filter/url.cpp
+++ b/filter/url.cpp
@@ -172,7 +172,7 @@ std::string get_base_url (Webserver_Request& webserver_request)
     scheme = "http";
     port = config::logic::http_network_port ();
   }
-  std::string url = scheme + "://" + webserver_request.host + ":" + port + "/";
+  std::string url = scheme + "://" + webserver_request.host + "/"; // remove port for #986 - reverse proxy
   return url;
 }
 


### PR DESCRIPTION
Allows for a reverse proxy, but removes the port and breaks the application when direct access is needed. (#986)

The real fix is to add a configuration flag to remove the port when hosted behind a reverse proxy. I can update this PR if direction is given on how to add a configuration on server setup.